### PR TITLE
IAV-X Details element Safari fix

### DIFF
--- a/styleguide/section-details.html
+++ b/styleguide/section-details.html
@@ -134,7 +134,7 @@ hide on demand.</p>
           <div class="kss-modifier__example">
             <details class="details ">
   <summary class="details__summary">Lorem ipsum dolor sit amet</summary>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a quam ut elit sodales scelerisque. Nunc dolor lorem, mattis quis risus pretium, pulvinar porta lorem. Nullam vestibulum lorem semper augue sagittis viverra. Aenean ac leo nec turpis tincidunt consequat. Quisque pellentesque metus sed mattis eleifend. Morbi blandit velit eget porta tempor. Etiam feugiat risus nec diam vestibulum porttitor. Duis consectetur, lorem vel ornare facilisis, urna tellus ultrices nibh, id convallis neque tortor ac augue. Praesent commodo lacus eu cursus feugiat. Duis id convallis arcu. Phasellus ante lacus, pharetra vitae consequat ac, finibus eget nisl.
+  <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a quam ut elit sodales scelerisque. Nunc dolor lorem, mattis quis risus pretium, pulvinar porta lorem. Nullam vestibulum lorem semper augue sagittis viverra. Aenean ac leo nec turpis tincidunt consequat. Quisque pellentesque metus sed mattis eleifend. Morbi blandit velit eget porta tempor. Etiam feugiat risus nec diam vestibulum porttitor. Duis consectetur, lorem vel ornare facilisis, urna tellus ultrices nibh, id convallis neque tortor ac augue. Praesent commodo lacus eu cursus feugiat. Duis id convallis arcu. Phasellus ante lacus, pharetra vitae consequat ac, finibus eget nisl.</div>
 </details>
 
           </div>
@@ -143,7 +143,7 @@ hide on demand.</p>
                   <div class="kss-markup kss-style">
             <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;details class=&quot;details &quot;&gt;
   &lt;summary class=&quot;details__summary&quot;&gt;Lorem ipsum dolor sit amet&lt;/summary&gt;
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a quam ut elit sodales scelerisque. Nunc dolor lorem, mattis quis risus pretium, pulvinar porta lorem. Nullam vestibulum lorem semper augue sagittis viverra. Aenean ac leo nec turpis tincidunt consequat. Quisque pellentesque metus sed mattis eleifend. Morbi blandit velit eget porta tempor. Etiam feugiat risus nec diam vestibulum porttitor. Duis consectetur, lorem vel ornare facilisis, urna tellus ultrices nibh, id convallis neque tortor ac augue. Praesent commodo lacus eu cursus feugiat. Duis id convallis arcu. Phasellus ante lacus, pharetra vitae consequat ac, finibus eget nisl.
+  &lt;div&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras a quam ut elit sodales scelerisque. Nunc dolor lorem, mattis quis risus pretium, pulvinar porta lorem. Nullam vestibulum lorem semper augue sagittis viverra. Aenean ac leo nec turpis tincidunt consequat. Quisque pellentesque metus sed mattis eleifend. Morbi blandit velit eget porta tempor. Etiam feugiat risus nec diam vestibulum porttitor. Duis consectetur, lorem vel ornare facilisis, urna tellus ultrices nibh, id convallis neque tortor ac augue. Praesent commodo lacus eu cursus feugiat. Duis id convallis arcu. Phasellus ante lacus, pharetra vitae consequat ac, finibus eget nisl.&lt;/div&gt;
 &lt;/details&gt;
 </code></pre>
           </div>

--- a/styles/components/details/details.twig
+++ b/styles/components/details/details.twig
@@ -1,4 +1,4 @@
 <details class="details {{ modifier_class }}">
   <summary class="details__summary">{{ summary }}</summary>
-  {{ content }}
+  <div>{{ content }}</div>
 </details>


### PR DESCRIPTION
Details element contents need to be inside some element. Otherwise Safari won't hide the contents when the details element is closed.